### PR TITLE
updated the CSS cards and added 6m sensor. 

### DIFF
--- a/MIKKO_CSS.md
+++ b/MIKKO_CSS.md
@@ -12,10 +12,11 @@ title: Overall propagation
 content: >-
     <table>   
     <tr>
-    <td></td><td><h3>10m-12m&nbsp;&nbsp;</h3></td><td><h3>15m-17m&nbsp;&nbsp;</h3></td><td><h3>20m-30m&nbsp;&nbsp;</h3></td><td><h3>40m-80m&nbsp;&nbsp;</h3></td>
+    <td></td><td><h3>6m&nbsp;&nbsp;</h3></td><td><h3>10m-12m&nbsp;&nbsp;</h3></td><td><h3>15m-17m&nbsp;&nbsp;</h3></td><td><h3>20m-30m&nbsp;&nbsp;</h3></td><td><h3>40m-80m&nbsp;&nbsp;</h3></td>
     </tr>    
     <tr>     
     <td><h3>Day</h3></td>   
+    <td><center><font color="{% if is_state('sensor.ham_radio_propagation_solar_hf_6_day', 'Good') %} #008000 {% elif is_state('sensor.ham_radio_propagation_solar_hf_6_day', 'Fair') %} #ffff00 {% elif is_state('sensor.ham_radio_propagation_solar_hf_6_day', 'Poor') %} #ff0000 {% endif %}"><h3>{{ states('sensor.ham_radio_propagation_solar_hf_6_day') }}</h3></font></center></td>
     <td><center><font color="{% if is_state('sensor.ham_radio_propagation_solar_hf_12_10_day', 'Good') %} #008000 {% elif is_state('sensor.ham_radio_propagation_solar_hf_12_10_day', 'Fair') %} #ffff00 {% elif is_state('sensor.ham_radio_propagation_solar_hf_12_10_day', 'Poor') %} #ff0000 {% endif %}"><h3>{{ states('sensor.ham_radio_propagation_solar_hf_12_10_day') }}</h3></font></center></td>     
     <td><center><font color="{% if is_state('sensor.ham_radio_propagation_solar_hf_17_15_day', 'Good') %} #008000 {% elif is_state('sensor.ham_radio_propagation_solar_hf_17_15_day', 'Fair') %} #ffff00 {% elif is_state('sensor.ham_radio_propagation_solar_hf_17_15_day', 'Poor') %} #ff0000 {% endif %}"><h3>{{ states('sensor.ham_radio_propagation_solar_hf_17_15_day') }}</h3></font></center></td>   
     <td><center><font color="{% if is_state('sensor.ham_radio_propagation_solar_hf_30_20_day', 'Good') %} #008000 {% elif is_state('sensor.ham_radio_propagation_solar_hf_30_20_day', 'Fair') %} #ffff00 {% elif is_state('sensor.ham_radio_propagation_solar_hf_30_20_day', 'Poor') %} #ff0000 {% endif %}"><h3>{{ states('sensor.ham_radio_propagation_solar_hf_30_20_day') }}</h3></font></center></td>   
@@ -23,6 +24,7 @@ content: >-
     </tr>    
     <tr>   
     <td><h3>Night</h3></td>    
+    <td><center><font color="{% if is_state('sensor.ham_radio_propagation_solar_hf_6_night', 'Good') %} #008000 {% elif is_state('sensor.ham_radio_propagation_solar_hf_6_night', 'Fair') %} #ffff00 {% elif is_state('sensor.ham_radio_propagation_solar_hf_6_night', 'Poor') %} #ff0000 {% else %} black {% endif %}"><h3>{{ states('sensor.ham_radio_propagation_solar_hf_6_night') }}</h3></font></center></td>
     <td><center><font color="{% if is_state('sensor.ham_radio_propagation_solar_hf_12_10_night', 'Good') %} #008000 {% elif is_state('sensor.ham_radio_propagation_solar_hf_12_10_night', 'Fair') %} #ffff00 {% elif is_state('sensor.ham_radio_propagation_solar_hf_12_10_night', 'Poor') %} #ff0000 {% else %} black {% endif %}"><h3>{{ states('sensor.ham_radio_propagation_solar_hf_12_10_night') }}</h3></font></center></td>     
     <td><center><font color="{% if is_state('sensor.ham_radio_propagation_solar_hf_17_15_night', 'Good') %} #008000 {% elif is_state('sensor.ham_radio_propagation_solar_hf_17_15_night', 'Fair') %} #ffff00 {% elif is_state('sensor.ham_radio_propagation_solar_hf_17_15_night', 'Poor') %} #ff0000 {% else %} black {% endif %}"><h3>{{ states('sensor.ham_radio_propagation_solar_hf_17_15_night') }}</h3></font></center></td>   
     <td><center><font color="{% if is_state('sensor.ham_radio_propagation_solar_hf_30_20_night', 'Good') %} #008000 {% elif is_state('sensor.ham_radio_propagation_solar_hf_30_20_night', 'Fair') %} #ffff00 {% elif is_state('sensor.ham_radio_propagation_solar_hf_30_20_night', 'Poor') %} #ff0000 {% else %} black {% endif %}"><h3>{{ states('sensor.ham_radio_propagation_solar_hf_30_20_night') }}</h3></font></center></td>   

--- a/custom_components/ham_radio_propagation/const.py
+++ b/custom_components/ham_radio_propagation/const.py
@@ -119,6 +119,16 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         icon="mdi:sine-wave",
     ),
     SensorEntityDescription(
+        key="solar_hf_6_day",
+        name="HF Conditions 6m Day",
+        icon="mdi:sine-wave",
+    ),
+    SensorEntityDescription(
+        key="solar_hf_6_night",
+        name="HF Conditions 6m Night",
+        icon="mdi:sine-wave",
+    ),
+    SensorEntityDescription(
         key="solar_geomag_field",
         name="HF Conditions Geomag Field",
         icon="mdi:compass",

--- a/custom_components/ham_radio_propagation/sensor.py
+++ b/custom_components/ham_radio_propagation/sensor.py
@@ -205,6 +205,8 @@ class HamRadioData:
         self.data["solar_hf_17_15_night"] = entry["hf_17_15_night"]
         self.data["solar_hf_12_10_day"] = entry["hf_12_10_day"]
         self.data["solar_hf_12_10_night"] = entry["hf_12_10_night"]
+        self.data["solar_hf_6_day"] = entry["hf_6_day"]
+        self.data["solar_hf_6_night"] = entry["hf_6_night"]
 
         self.data["solar_geomag_field"] = entry["geomagfield"]
         self.data["solar_sig_noise_lvl"] = entry["signalnoise"]


### PR DESCRIPTION
I have updated the CSS cards in MIKKO_CSS.md to include the 6m band that was missing from the visualization.

Changes made:

Added a new column for the 6m band in the "Overall propagation" card table
Added sensor entries for both day and night conditions for the 6m band
Added sensor for 6m band day/night. 
Applied the same conditional formatting (color coding for Good/Fair/Poor conditions) as used by the other bands
The CSS cards now properly reflect all the bands supported by the API, which includes:

6m band (50-54 MHz)
10m-12m bands (24.89-29.7 MHz)
15m-17m bands (18.068-21.45 MHz)
20m-30m bands (10.1-14.35 MHz)
40m-80m bands (3.5-7.3 MHz)
The update ensures that users can now monitor propagation conditions for all supported frequency bands in the same consistent visual format.